### PR TITLE
ESLint 2.0.0

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@ var config = require("../")
 var test = require("tape")
 
 test("test basic properties of config", function (t) {
-  t.ok(isObject(config.ecmaFeatures), "features is object")
+  t.ok(isObject(config.parserOptions), "features is object")
   t.ok(isObject(config.env), "env is object")
   t.ok(isObject(config.rules), "rules is object")
   t.end()

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
-  "ecmaFeatures": {
-    "modules": true
+  "parserOptions": {
+    "sourceType": "module"
   },
   "env": {
     "es6": true,

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -16,15 +16,15 @@
     "indent": [ 2, 2, {
       "SwitchCase": 1
     } ],
-    "quotes": [ 2, "double" ],
+    "keyword-spacing": 2,
     "no-console": 0,
     "no-multiple-empty-lines": [ 2, {
       "max": 1
     } ],
     "no-use-before-define": [ 2, "nofunc" ],
     "object-curly-spacing": [2, "always"],
+    "quotes": [ 2, "double" ],
     "semi": [ 2, "never" ],
-    "space-after-keywords": [ 2, "always" ],
     "space-before-blocks": [ 2, "always" ],
     "space-before-function-paren": [ 2, {
       "anonymous": "always",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "type": "git",
     "url": "https://github.com/stylelint/eslint-config-stylelint.git"
   },
+  "homepage": "https://github.com/stylelint/eslint-config-stylelint",
+  "bugs": "https://github.com/stylelint/eslint-config-stylelint/issues",
   "main": "index.js",
   "files": [
     "eslintrc.json",
     "index.js"
   ],
   "devDependencies": {
-    "eslint": "^1.0.0",
+    "eslint": "^2.0.0",
     "tape": "^4.0.2"
   },
   "scripts": {


### PR DESCRIPTION
Updates ESLint rules for 2.0.0 compat per the [migration guide](http://eslint.org/docs/user-guide/migrating-to-2.0.0)
• Switches from `space-after-keywords` deprecated rule to `keyword-spacing` rule
• Moves the `quotes` rule to correct position for alphabetical order of rules
• Adds `homepage` and `bugs` recommended fields to `package.json`