### PR TITLE
feat: Add `jest` as an ESLint environment and switch tests from tape to jest

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,14 +1,12 @@
 var config = require("../")
-var test = require("tape")
 
-test("test basic properties of config", function (t) {
-  t.ok(isObject(config.parserOptions), "features is object")
-  t.ok(isObject(config.env), "env is object")
-  t.ok(isObject(config.rules), "rules is object")
-  t.end()
+it("Test basic properties of config", function () {
+  expect(isObject(config.parserOptions)).toBeTruthy()
+  expect(isObject(config.env)).toBeTruthy()
+  expect(isObject(config.rules)).toBeTruthy()
 })
 
-test("load config in eslint to validate all rule syntax is correct", function (t) {
+it("Load config in ESLint to validate all rule syntax is correct", function () {
   var CLIEngine = require("eslint").CLIEngine
 
   var cli = new CLIEngine({
@@ -16,8 +14,7 @@ test("load config in eslint to validate all rule syntax is correct", function (t
     configFile: "eslintrc.json",
   })
 
-  t.ok(cli.executeOnText("var foo\n"), "can executeOnText")
-  t.end()
+  expect(cli.executeOnText("var foo\n")).toBeTruthy()
 })
 
 function isObject(obj) {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,12 +1,12 @@
 var config = require("../")
 
-it("Test basic properties of config", function () {
+it("test basic properties of config", function () {
   expect(isObject(config.parserOptions)).toBeTruthy()
   expect(isObject(config.env)).toBeTruthy()
   expect(isObject(config.rules)).toBeTruthy()
 })
 
-it("Load config in ESLint to validate all rule syntax is correct", function () {
+it("load config in ESLint to validate all rule syntax is correct", function () {
   var CLIEngine = require("eslint").CLIEngine
 
   var cli = new CLIEngine({

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -5,6 +5,7 @@
   },
   "env": {
     "es6": true,
+    "jest": true,
     "node": true
   },
   "rules": {
@@ -42,6 +43,6 @@
     "space-in-parens": [ 2, "never" ],
     "space-infix-ops": 2,
     "space-unary-ops": 2,
-    "spaced-comment": [ 2, "always" ]    
+    "spaced-comment": [ 2, "always" ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
   },
   "devDependencies": {
     "eslint": "^3.0.0",
-    "npmpub": "^3.0.3",
-    "tape": "^4.4.0"
+    "jest": "^17.0.3",
+    "npmpub": "^3.0.3"
   },
   "scripts": {
+    "jest": "jest",
     "lint": "eslint -c eslintrc.json .",
-    "tape": "tape \"__tests__/**/*.js\"",
-    "test": "npm run lint && npm run tape",
-    "release": "npmpub"
+    "release": "npmpub",
+    "test": "npm run lint && npm run jest",
+    "watch": "jest --watch"
   }
 }


### PR DESCRIPTION
I _think_ this would be released as a _minor_ semver update, i.e. `5.1.0`:
• Adding `jest` as an additional environment variable should not cause CI failures