### PR TITLE
Switch `array-bracket-spacing` to use `never` option

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -9,9 +9,7 @@
     "node": true
   },
   "rules": {
-    "array-bracket-spacing": [2, "always", {
-      "singleValue": false
-    } ],
+    "array-bracket-spacing": [ 2, "never" ],
     "arrow-spacing": 2,
     "block-spacing": 2,
     "comma-dangle": [ 2, "always-multiline" ],


### PR DESCRIPTION
Ref: #17 

ESLint rule docs: Notes: http://eslint.org/docs/rules/array-bracket-spacing

The `array-bracket-spacing` is _fixable_ using `--fix` on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix).