### PR TITLE
Allow template literals for quotes

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -36,7 +36,9 @@
     "object-shorthand": 2,
     "padded-blocks": [2, "never"],
     "prefer-const": 2,
-    "quotes": [ 2, "double" ],
+    "quotes": [ 2, "double", {
+      "allowTemplateLiterals": true
+    } ],
     "semi": [ 2, "never" ],
     "space-before-blocks": [ 2, "always" ],
     "space-before-function-paren": [ 2, {


### PR DESCRIPTION
There are lot's of escaped double quotes within a string in stylelint's codebase. For example, [at-rule-name-space-after's tests](https://github.com/stylelint/stylelint/blob/master/lib/rules/at-rule-name-space-after/__tests__/index.js). This addition will allow us to have less cluttered strings.

```js
// Before
"@charset \"UTF-8\";"

// After
`@charset "UTF-8";`
```

It shouldn't break a build, because both of variants above are accepted.

[Reference](http://eslint.org/docs/rules/quotes#allowtemplateliterals).