### PR TITLE
Add `max-len` rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -22,6 +22,12 @@
     } ],
     "keyword-spacing": 2,
     "linebreak-style": 2,
+    "max-len": [ 2, 120, {
+      "ignoreComments": true,
+      "ignoreStrings": true,
+      "ignoreTemplateLiterals": true,
+      "ignoreUrls": true
+    } ],
     "no-console": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-multi-spaces": 2,


### PR DESCRIPTION
https://github.com/stylelint/eslint-config-stylelint/issues/22

`"max-len": [ 2, 120 ]` throws 169 errors on stylelint v8 branch, but with additional options there are only 29 errors.