### PR TITLE
Prepare for prettier

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -8,53 +8,16 @@
     "jest": true,
     "node": true
   },
+  "plugins": [
+    "sort-requires"
+  ],
   "rules": {
-    "array-bracket-spacing": [ 2, "never" ],
-    "arrow-spacing": 2,
-    "block-spacing": 2,
-    "comma-dangle": [ 2, "always-multiline" ],
-    "comma-spacing": 2,
-    "comma-style": [ 2, "last" ],
-    "eol-last": 2,
-    "eqeqeq": 2,
-    "indent": [ 2, 2, {
-      "SwitchCase": 1
-    } ],
-    "keyword-spacing": 2,
-    "linebreak-style": 2,
-    "max-len": [ 2, 120, {
-      "ignoreComments": true,
-      "ignoreStrings": true,
-      "ignoreTemplateLiterals": true,
-      "ignoreUrls": true
-    } ],
-    "no-console": 2,
-    "no-mixed-spaces-and-tabs": 2,
-    "no-multi-spaces": 2,
-    "no-multiple-empty-lines": [ 2, {
-      "max": 1
-    } ],
-    "no-trailing-spaces": 2,
-    "no-use-before-define": [ 2, "nofunc" ],
-    "no-var": 2,
-    "no-whitespace-before-property": 2,
-    "object-curly-spacing": [2, "always"],
-    "object-shorthand": 2,
-    "padded-blocks": [2, "never"],
-    "prefer-const": 2,
-    "quotes": [ 2, "double", {
-      "allowTemplateLiterals": true
-    } ],
-    "semi": [ 2, "never" ],
-    "space-before-blocks": [ 2, "always" ],
-    "space-before-function-paren": [ 2, {
-      "anonymous": "always",
-      "named": "never"
-    } ],
-    "space-in-parens": [ 2, "never" ],
-    "space-infix-ops": 2,
-    "space-unary-ops": 2,
-    "strict": ["error", "global"],
-    "template-curly-spacing": 2
+    "eqeqeq": "error",
+    "no-use-before-define": ["error", "nofunc"],
+    "no-var": "error",
+    "object-shorthand": "error",
+    "prefer-const": "error",
+    "sort-requires/sort-requires": "error",
+    "strict": ["error", "global"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "release": "npmpub",
     "test": "npm run lint && npm run jest",
     "watch": "jest --watch"
+  },
+  "dependencies": {
+    "eslint-plugin-sort-requires": "^2.1.0"
   }
 }


### PR DESCRIPTION
This prepares the config for use with prettier. It removes the stylistic rules, while keeping the additional error checking and best practise that we’ve added on top of `eslint:recommended`.

Additionally, I’ve added a plugin to ensure `require()`s are alphabetically ordered as this helps with quickly parsing what utils etc a rule is using. The rule can be auto fixed, so rolling it out across the code base will be a breeze.