### PR TITLE
Add one-var rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,7 +20,7 @@
     "no-use-before-define": ["error", "nofunc"],
     "no-var": "error",
     "object-shorthand": "error",
-    "one-var": ["error", "always"],
+    "one-var": ["error", "never"],
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"]

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,6 +20,7 @@
     "no-use-before-define": ["error", "nofunc"],
     "no-var": "error",
     "object-shorthand": "error",
+    "one-var": ["error", "always"],
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"]


### PR DESCRIPTION
https://eslint.org/docs/rules/one-var

We use one `let`, `const` per assignment in our code. [Sometimes](https://github.com/stylelint/stylelint/blob/c7c964f9c5cd503b61a385d2b175445498136bf1/lib/rules/value-no-vendor-prefix/index.js#L50-L52) this rule is broken.