### PR TITLE
Bump minimum Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
     - node_modules
 
 node_js:
+  - '9'
   - '8'
   - '6'
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=4.2.1"
+    "node": ">=6"
   },
   "devDependencies": {
     "eslint": "^4.6.1",


### PR DESCRIPTION
This bumps the minimum Node.js version to `"node": ">=6"` the same [as stylelint](https://github.com/stylelint/stylelint/blob/f45dd0ba88ae7aeab03e07001c04171fc2a2e2da/package.json#L39)

Also adds Node.js 9.x to Travis CI