### PR TITLE
Add eslint-plugin-jest

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,14 +1,14 @@
 {
   "extends": [
     "eslint:recommended",
-    "plugin:node/recommended"
+    "plugin:node/recommended",
+    "plugin:jest/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 6
   },
   "env": {
     "es6": true,
-    "jest": true,
     "node": true
   },
   "plugins": [
@@ -23,6 +23,7 @@
     "one-var": ["error", "never"],
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
-    "strict": ["error", "global"]
+    "strict": ["error", "global"],
+    "jest/no-identical-title": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "watch": "jest --watch"
   },
   "dependencies": {
+    "eslint-plugin-jest": "^21.22.0",
     "eslint-plugin-node": "^7.0.0",
     "eslint-plugin-sort-requires": "^2.1.0"
   }


### PR DESCRIPTION
Hi, stylelint team!

This pull request adds [`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest) to improve our DX.

- Fixes stylelint/stylelint#3647.
- Enable the [`recommended configuration`](https://github.com/jest-community/eslint-plugin-jest/blob/v21.22.0/index.js#L29).

This change produces so many warnings for our code base. The following rules:

- [`jest/prefer-to-have-length`](https://github.com/jest-community/eslint-plugin-jest/blob/v21.22.0/docs/rules/prefer-to-have-length.md)
  - This rule supports auto-fixing, so easy to fix.
  - In the recommended configuration, this rule is `warn`. So we may not need to fix it.
- [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/v21.22.0/docs/rules/no-identical-title.md)
  - This rule points bugs in test code maybe, so we must fix manually.
  - In the recommended configuration, this rule is `error`. But `error` is too strict for current our code base, so I think better to set `warn` at first. We can fix gradually, then finally we can change it from `warn` to `error`.

What do you think about this change?
Please give me any feedback!

Thanks.