### PR TITLE
Switch eslint-plugin-jest rules from warn to error

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -24,6 +24,6 @@
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"],
-    "jest/no-identical-title": "warn"
+    "jest/prefer-to-have-length": "error"
   }
 }


### PR DESCRIPTION
Follow-up to #53, via https://github.com/stylelint/stylelint/pull/3689#issuecomment-424256507.

Changes violations of `jest/no-identical-title` and `jest/prefer-to-have-length` to be marked as errors instead of warnings. This is part of the recommended config for `jest/no-identical-title` so I removed the local override.