### PR TITLE
Add more Jest rules

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -70,6 +70,11 @@ module.exports = {
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"],
-    "jest/prefer-to-have-length": "error"
+    "jest/no-alias-methods": "error",
+    "jest/prefer-to-be-null": "error",
+    "jest/prefer-to-be-undefined": "error",
+    "jest/prefer-to-contain": "error",
+    "jest/prefer-to-have-length": "error",
+    "jest/valid-expect-in-promise": "error",
   }
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "watch": "jest --watch"
   },
   "dependencies": {
-    "eslint-plugin-jest": "^21.22.0",
+    "eslint-plugin-jest": "^21.25.1",
     "eslint-plugin-node": "^7.0.0",
     "eslint-plugin-sort-requires": "^2.1.0"
   }


### PR DESCRIPTION
Added [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md) to avoid error in a test like this one: https://github.com/stylelint/stylelint/pull/3731

The rest functions just to keep tests tidy.