### PR TITLE
Add eslint-plugin-eslint-comments

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   "extends": [
     "eslint:recommended",
+    "plugin:eslint-comments/recommended",
     "plugin:node/recommended",
     "plugin:jest/recommended",
     "plugin:jest/style",
@@ -71,5 +72,6 @@ module.exports = {
     "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"],
+    "eslint-comments/no-unused-disable": "error",
   }
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "watch": "jest --watch"
   },
   "dependencies": {
+    "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-jest": "^22.0.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-sort-requires": "^2.1.0"


### PR DESCRIPTION
`eslint-plugin-eslint-comments` provides rules to apply best practices on ESLint directive comments.

For example, it detects:

- Unused disable comments
- Useless enable comments
- Abuse disable comments (e.g. `/* eslint-disable */` at the beginning of file)

See also:

- https://github.com/mysticatea/eslint-plugin-eslint-comments
- https://mysticatea.github.io/eslint-plugin-eslint-comments
