### PR TITLE
Add `no-console` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 11.1.0
+
+-   Fixed: Add the `no-console` rule that was removed from `eslint/recommended` in ESLint v6.
+
 # 11.0.0
 
 -   Added: `eslint-plugin-eslint-comments` ESLint plugin using `eslint-comments/recommended`  rules.

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   ],
   "rules": {
     "eqeqeq": "error",
+    "no-console": "error",
     "no-use-before-define": ["error", "nofunc"],
     "no-var": "error",
     "object-shorthand": "error",


### PR DESCRIPTION
The `no-console` rule was removed from ESLint v6
> https://eslint.org/docs/user-guide/migrating-to-6.0.0

Adding it back into the config here for:
> https://github.com/stylelint/stylelint/pull/4196