### PR TITLE
Remove `prefer-const`

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -70,7 +70,6 @@ module.exports = {
         "next": "*"
       }
     ],
-    "prefer-const": "error",
     "sort-requires/sort-requires": "error",
     "strict": ["error", "global"],
     "eslint-comments/no-unused-disable": "error",


### PR DESCRIPTION
Personally, I don't see much benefit in enforcing using `const` whenever possible. In my experience, it have never saved me from a bug, but annoyed a lot, when I had to change from/to `let`.

Here's an Dan Abramov's [article about `prefer-const`](https://overreacted.io/on-let-vs-const/), pros and cons.

This discussion could be heated. So to avoid wasting our time trying to convince on another, lets allow everyone state their position **once**. And then we can vote. Put 👍under this comment for accepting, and 👎for declining change. Only @stylelint members votes would be counted.

We're _not_ going to merge if we have more downvotes, even if this PR would be approved with review system.