### PR TITLE
Align with configuration in main repo

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,57 +1,72 @@
 "use strict";
 
 module.exports = {
-  "extends": [
+  parserOptions: {
+    ecmaVersion: 2019,
+  },
+  env: {
+    es6: true,
+    node: true,
+  },
+  plugins: ["node", "sort-requires"],
+  extends: [
     "eslint:recommended",
     "plugin:eslint-comments/recommended",
     "plugin:node/recommended",
     "plugin:jest/recommended",
     "plugin:jest/style",
-    "prettier"
+    "prettier",
   ],
-  "parserOptions": {
-    "ecmaVersion": 2019
-  },
-  "env": {
-    "es6": true,
-    "node": true
-  },
-  "plugins": [
-    "node",
-    "sort-requires"
-  ],
-  "rules": {
+  rules: {
     "array-callback-return": "error",
     "dot-notation": "error",
-    "eqeqeq": "error",
+    eqeqeq: ["error", "smart"],
     "eslint-comments/no-unused-disable": "error",
     "func-name-matching": "error",
     "guard-for-in": "error",
     "no-confusing-arrow": [
       "error",
       {
-        "allowParens": false
-      }
+        allowParens: false,
+      },
     ],
     "no-console": "error",
     "no-else-return": [
       "error",
       {
-        "allowElseIf": false
-      }
+        allowElseIf: false,
+      },
     ],
     "no-implicit-coercion": "error",
     "no-lonely-if": "error",
     "no-unneeded-ternary": "error",
-    "no-use-before-define": ["error", "nofunc"],
-    "no-useless-return": "error",
     "no-unused-vars": [
       "error",
       {
-        "ignoreRestSiblings": true
-      }
+        ignoreRestSiblings: true,
+      },
     ],
+    "no-use-before-define": ["error", "nofunc"],
+    "no-useless-return": "error",
     "no-var": "error",
+    "node/no-unsupported-features/es-builtins": [
+      "error",
+      {
+        version: ">=10.18.0",
+      },
+    ],
+    "node/no-unsupported-features/es-syntax": [
+      "error",
+      {
+        version: ">=10.18.0",
+      },
+    ],
+    "node/no-unsupported-features/node-builtins": [
+      "error",
+      {
+        version: ">=10.18.0",
+      },
+    ],
     "object-shorthand": "error",
     "one-var": ["error", "never"],
     "operator-assignment": "error",
@@ -59,45 +74,45 @@ module.exports = {
       "error",
       // Require blank lines after all directive prologues (e. g. 'use strict')
       {
-        "blankLine": "always",
-        "prev": "directive",
-        "next": "*"
+        blankLine: "always",
+        prev: "directive",
+        next: "*",
       },
       // Disallow blank lines between all directive prologues (e. g. 'use strict')
       {
-        "blankLine": "never",
-        "prev": "directive",
-        "next": "directive"
+        blankLine: "never",
+        prev: "directive",
+        next: "directive",
       },
       // Require blank lines after every sequence of variable declarations
       {
-        "blankLine": "always",
-        "prev": ["const", "let", "var"],
-        "next": "*"
+        blankLine: "always",
+        prev: ["const", "let", "var"],
+        next: "*",
       },
       // Blank lines could be between variable declarations
       {
-        "blankLine": "any",
-        "prev": ["const", "let", "var"],
-        "next": ["const", "let", "var"]
+        blankLine: "any",
+        prev: ["const", "let", "var"],
+        next: ["const", "let", "var"],
       },
       // Require blank lines before all return statements
       {
-        "blankLine": "always",
-        "prev": "*",
-        "next": "return"
+        blankLine: "always",
+        prev: "*",
+        next: "return",
       },
       // Require blank lines before and after all following statements
       {
-        "blankLine": "always",
-        "prev": "*",
-        "next": ["for", "function", "if", "switch", "try"]
+        blankLine: "always",
+        prev: "*",
+        next: ["for", "function", "if", "switch", "try"],
       },
       {
-        "blankLine": "always",
-        "prev": ["for", "function", "if", "switch", "try"],
-        "next": "*"
-      }
+        blankLine: "always",
+        prev: ["for", "function", "if", "switch", "try"],
+        next: "*",
+      },
     ],
     "prefer-arrow-callback": "error",
     "prefer-object-spread": "error",
@@ -106,6 +121,6 @@ module.exports = {
     "prefer-spread": "error",
     "prefer-template": "error",
     "sort-requires/sort-requires": "error",
-    "strict": ["error", "global"],
-  }
+    strict: ["error", "global"],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
     "np": "^6.2.0"
   },
   "scripts": {
-    "jest": "jest",
     "lint": "eslint -c eslintrc.js .",
     "release": "np",
-    "test": "npm run lint && npm run jest",
+    "test": "jest",
     "watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Part of standardisation stream of work.

Closes https://github.com/stylelint/eslint-config-stylelint/issues/69

> Is there anything in the PR that needs further explanation?

There are duplicated rules configured in the [`stylelint/stylelint/package.json`](https://github.com/stylelint/stylelint/blob/643289bac28d854009e3eb2da99f388ae3d06975/package.json#L151-L215) and a few additional rules:

```
  "eslintConfig": {
    "parserOptions": {
      "ecmaVersion": 2019
    },
    "extends": [
      "stylelint"
    ],
    "globals": {
      "testRule": true
    },
    "rules": {
      "array-callback-return": "error",
      "dot-notation": "error",
      "func-name-matching": "error",
      "guard-for-in": "error",
      "no-confusing-arrow": [
        "error",
        {
          "allowParens": false
        }
      ],
      "no-else-return": [
        "error",
        {
          "allowElseIf": false
        }
      ],
      "no-implicit-coercion": "error",
      "no-lonely-if": "error",
      "no-mixed-spaces-and-tabs": "off",
      "no-unneeded-ternary": "error",
      "no-useless-return": "error",
      "no-unused-vars": [
        "error",
        {
          "ignoreRestSiblings": true
        }
      ],
      "operator-assignment": "error",
      "prefer-arrow-callback": "error",
      "prefer-object-spread": "error",
      "prefer-regex-literals": "error",
      "prefer-rest-params": "error",
      "prefer-spread": "error",
      "prefer-template": "error",
      "node/no-unsupported-features/es-builtins": [
        "error",
        {
          "version": ">=10.18.0"
        }
      ],
      "node/no-unsupported-features/es-syntax": [
        "error",
        {
          "version": ">=10.18.0"
        }
      ],
      "node/no-unsupported-features/node-builtins": [
        "error",
        {
          "version": ">=10.18.0"
        }
      ]
    }
  },
```

This pull request brings the shareable configuration up to date. The configuration in the main repo will then becomes:

```
"extends": [
      "stylelint"
    ],
    "globals": {
      "testRule": true
    },
```

Once this is merged, I'll create a follow-up pull request to prepare this shareable configuration as `@stylelint/eslint-config@12` to align with the upcoming releases of `@stylelint/prettier-config` and `@stylelint/remark-preset`.