### PR TITLE
Add `no-shadow` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     ],
     "no-implicit-coercion": "error",
     "no-lonely-if": "error",
+    "no-shadow": "error",
     "no-unneeded-ternary": "error",
     "no-unused-vars": [
       "error",


### PR DESCRIPTION
This enables the [`no-shadow`](https://eslint.org/docs/rules/no-shadow) rule.
See <https://github.com/stylelint/stylelint/issues/4985> for the reasons.

> Which issue, if any, is this issue related to?

Related to https://github.com/stylelint/stylelint/issues/4985 and https://github.com/stylelint/stylelint/pull/4986

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
