### PR TITLE
Add Node.js 14 to CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12]
+        node: [10, 12, 14]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 14 [goes LTS on 2020-10-27](https://nodejs.org/en/about/releases/).

See also <https://github.com/stylelint/stylelint/pull/4976>

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
