### PR TITLE
Add `allow` option to `no-console`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,12 @@ module.exports = {
         allowParens: false,
       },
     ],
-    "no-console": "error",
+    "no-console": [
+      "error",
+      {
+        allow: ["warn", "error"],
+      },
+    ],
     "no-else-return": [
       "error",
       {


### PR DESCRIPTION
Given (`foo.js`):

```js
"use strict";

console.log("");
console.warn("");
console.error("");
```

Before:

```
foo.js:3:1: Unexpected console statement. [Error/no-console]
foo.js:4:1: Unexpected console statement. [Error/no-console]
foo.js:5:1: Unexpected console statement. [Error/no-console]
```

After:

```
foo.js:3:1: Unexpected console statement. [Error/no-console]
```

> Which issue, if any, is this issue related to?

Close #108

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
