### PR TITLE
Update node version ranges to align with stylelint v14

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,24 +55,9 @@ module.exports = {
     "no-use-before-define": ["error", "nofunc"],
     "no-useless-return": "error",
     "no-var": "error",
-    "node/no-unsupported-features/es-builtins": [
-      "error",
-      {
-        version: ">=10.18.0",
-      },
-    ],
-    "node/no-unsupported-features/es-syntax": [
-      "error",
-      {
-        version: ">=10.18.0",
-      },
-    ],
-    "node/no-unsupported-features/node-builtins": [
-      "error",
-      {
-        version: ">=10.18.0",
-      },
-    ],
+    "node/no-unsupported-features/es-builtins": "error",
+    "node/no-unsupported-features/es-syntax": "error",
+    "node/no-unsupported-features/node-builtins": "error",
     "object-shorthand": "error",
     "one-var": ["error", "never"],
     "operator-assignment": "error",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "files": [
     ".eslintrc.js"
   ],
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "devDependencies": {
     "eslint": "^7.3.1",
     "jest": "^26.4.2",


### PR DESCRIPTION
Updates to align with stylelint v14: https://github.com/stylelint/stylelint/issues/5205

The explicit version ranges have been dropped. `node/no-unsupported-features` is smart enough to pull this from the node engine field of the host project for the version range. Now the two won't fall out of alignment!

I've checked this by linking and fiddling about with the engine field of another project (see attached screen recording, in which I've removes comments to disable checks around fs/promises).


https://user-images.githubusercontent.com/824753/118365313-0f374600-b594-11eb-9c76-1b281d7e93a1.mov


