### PR TITLE
Update configuration for ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,19 @@
 "use strict";
 
+// eslint-disable-next-line no-undef -- Keep backward compatibility with CommonJS.
 module.exports = {
   parserOptions: {
     ecmaVersion: 2019,
+    sourceType: "module",
   },
   env: {
     es6: true,
     node: true,
   },
-  plugins: ["eslint-comments", "jest", "node", "sort-requires"],
   extends: [
     "eslint:recommended",
     "plugin:eslint-comments/recommended",
-    "plugin:node/recommended",
+    "plugin:node/recommended-module",
     "plugin:jest/recommended",
     "plugin:jest/style",
     "prettier",
@@ -111,7 +112,6 @@ module.exports = {
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
-    "sort-requires/sort-requires": "error",
-    strict: ["error", "global"],
+    "sort-imports": ["error", { allowSeparatedGroups: true }],
   },
 };

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const config = require("../");
+// eslint-disable-next-line no-undef -- Keep backward compatibility with CommonJS.
+const config = require("../index");
 
 it("test basic properties of config", () => {
   expect(isObject(config.parserOptions)).toBeTruthy();
@@ -9,6 +10,7 @@ it("test basic properties of config", () => {
 });
 
 it("load config in ESLint to validate all rule syntax is correct", () => {
+  // eslint-disable-next-line no-undef -- Keep backward compatibility with CommonJS.
   const CLIEngine = require("eslint").CLIEngine;
 
   const cli = new CLIEngine({

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 "use strict";
 
+// eslint-disable-next-line no-undef -- Keep backward compatibility with CommonJS.
 module.exports = require("./.eslintrc.js");

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-jest": "^24.3.6",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-sort-requires": "^2.1.0"
+        "eslint-plugin-node": "^11.1.0"
       },
       "devDependencies": {
         "eslint": "^7.26.0",
@@ -3264,11 +3263,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/eslint-plugin-sort-requires": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-requires/-/eslint-plugin-sort-requires-2.1.0.tgz",
-      "integrity": "sha1-PvrZSNyDeYIZ6An1QGfEDlVESGE="
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -14391,11 +14385,6 @@
         "resolve": "^1.10.1",
         "semver": "^6.1.0"
       }
-    },
-    "eslint-plugin-sort-requires": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-requires/-/eslint-plugin-sort-requires-2.1.0.tgz",
-      "integrity": "sha1-PvrZSNyDeYIZ6An1QGfEDlVESGE="
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-jest": "^24.3.6",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-sort-requires": "^2.1.0"
+    "eslint-plugin-node": "^11.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to stylelint/stylelint#5291

> Is there anything in the PR that needs further explanation?

We are moving to ESM on the `stylelint/stylelint` repo: stylelint/stylelint#5291
This update will be required for the migration.

- Replace [`eslint-plugin-sort-requires`](https://github.com/kentor/eslint-plugin-sort-requires) with the core rule [`sort-imports`](https://eslint.org/docs/rules/sort-imports)
  - This change may cause many importing changes...
- Keep this package CommonJS still because ESLint does not seem to support ESM (see eslint/rfcs#9)

I think some changes may be controversial. Please give me feedback!
