### PR TITLE
Test only for Node.js LTS on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,3 +15,5 @@ jobs:
 
   test:
     uses: stylelint/.github/.github/workflows/test.yml@main
+    with:
+      node-version: '["lts/*"]'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/eslint-config-stylelint/pull/190#pullrequestreview-1095516960

> Is there anything in the PR that needs further explanation?

We usually run linting only for Node.js LTS on CI:

https://github.com/stylelint/.github/blob/7288d228eb3e2ad6bdf9b80afb0b28d502756b35/.github/workflows/lint.yml#L9
