### PR TITLE
Update `parserOptions.ecmaVersion` from `2019` to `2020`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-undef -- Keep backward compatibility with CommonJS.
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
     sourceType: "module",
   },
   env: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/6311
(Stylelint 15.0.0 will drop the support for Node.js 12.)

> Is there anything in the PR that needs further explanation?

Node.js 14.5.0 covers more than 90% of the ES2020 features. See [node.green/#ES2020](https://node.green/#ES2020):

<img width="147" alt="image" src="https://user-images.githubusercontent.com/473530/204798410-b032c23a-8a37-41c2-b944-2b48622d05f8.png">

