### PR TITLE
Add `eslint` to `peerDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "jest": "^29.3.1",
         "np": "^7.6.3",
         "prettier": "^2.8.1"
+      },
+      "peerDependencies": {
+        "eslint": ">= 8.33.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "np": "^7.6.3",
     "prettier": "^2.8.1"
   },
+  "peerDependencies": {
+    "eslint": ">= 8.33.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Is there anything in the PR that needs further explanation?

Following the instruction of ESLint:

> You should declare your dependency on ESLint in `package.json` using the `peerDependencies` field.

See https://eslint.org/docs/latest/extend/shareable-configs#publishing-a-shareable-config
