### PR TITLE
Change `parserOptions.ecmaVersion` from `2020` to `2021`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	parserOptions: {
-		ecmaVersion: 2020,
+		ecmaVersion: 2021,
 		sourceType: 'module',
 	},
 	env: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #220

> Is there anything in the PR that needs further explanation?

`eslint-plugin-n@16.0.0` defaults to `ecmaVersion: 2021`, see:
https://github.com/eslint-community/eslint-plugin-n/releases/tag/16.0.0
