### PR TITLE
Add rules for ESM files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: rules for ESM files.
+
 ## 19.0.0
 
 - Removed: Node.js 14 support.

--- a/index.js
+++ b/index.js
@@ -112,4 +112,13 @@ module.exports = {
 		// Prefer code readability, e.g. `[0-9A-Za-z]`.
 		'regexp/prefer-d': 'off',
 	},
+	overrides: [
+		{
+			files: ['*.mjs'],
+			rules: {
+				'no-restricted-globals': ['error', 'module', 'require'],
+				strict: ['error', 'never'],
+			},
+		},
+	],
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/5291

> Is there anything in the PR that needs further explanation?

This change suggests adding the following rules for ESM files.

- [no-restricted-globals](https://eslint.org/docs/latest/rules/no-restricted-globals)
  - Disallow the use of CJS global objects.
- [strict](https://eslint.org/docs/latest/rules/strict)
  - Disallow the `'use strict'` directive.

Someone may disagree with using `overrides` in sharable configs. Please let me know if you have concerns.

---

### Motivation

I want to automatically check ESM files during the migration from CJS to ESM in the [stylelint/stylelint](https://github.com/stylelint/stylelint) repository.

Also, I believe these enabled rules are useful for other projects.
