### PR TITLE
Add `n/prefer-global/process` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `n/prefer-global/process` rule.
+
 ## 19.1.0
 
 - Added: rules for ESM files.

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ module.exports = {
 		'prefer-template': 'error',
 		'sort-imports': ['error', { allowSeparatedGroups: true }],
 
+		// Avoid a global variable unique to Node.js.
+		'n/prefer-global/process': ['error', 'never'],
+
 		// Prefer code readability, e.g. `[0-9A-Za-z]`.
 		'regexp/prefer-d': 'off',
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/7139

> Is there anything in the PR that needs further explanation?

Global variables are often harmful. Unlike global variables defined in standard specs (ECMAScript or WHATWG etc.),
`process` is unique to Node.js. This may be a problem when running Stylelint on other platforms.

See https://github.com/eslint-community/eslint-plugin-n/blob/v11.1.0/docs/rules/prefer-global/process.md
