### PR TITLE
Remove Node.js 16 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Removed: Node.js 16 support.
+
 ## 20.0.0
 
 - Added: `n/prefer-global/process` rule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "prettier": "^3.0.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.33.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 16 reaches End-of-Life.
