### PR TITLE
Change `parserOptions.ecmaVersion` from `2021` to `2023`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed: Node.js 16 support.
 - Changed: bump `eslint-plugin-regexp` from v1 to v2.
+- Changed: `parserOptions.ecmaVersion` from `2021` to `2023`.
 
 ## 20.0.0
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	parserOptions: {
-		ecmaVersion: 2021,
+		ecmaVersion: 2023,
 		sourceType: 'module',
 	},
 	env: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #246

> Is there anything in the PR that needs further explanation?

This package supports Node.js 18 or later, which is over 90% compatible with ECMAScript 2023.
See also https://node.green/#ES2023
