### PR TITLE
Exclude ESLint deps from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
+        exclude-patterns: ['eslint', 'eslint-*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #260

> Is there anything in the PR that needs further explanation?

ESLint dependencies are important, so we should update them separately.
