### PR TITLE
Remove needless Dependabot branches from CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'dependabot/**'
   pull_request:
   merge_group:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Dependabot always creates a PR when pushing commits, so specifying the branches is unnecessary.

