### PR TITLE
Remove `no-confusing-arrow` because of the deprecation of formatting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Head
 
+- Removed: `no-confusing-arrow` because of the deprecation of formatting rules.
 - Fixed: missing `funding` field in `package.json`.
 
 ## 21.0.0

--- a/index.js
+++ b/index.js
@@ -23,12 +23,6 @@ module.exports = {
 		'func-name-matching': 'error',
 		'func-names': ['error', 'as-needed'],
 		'guard-for-in': 'error',
-		'no-confusing-arrow': [
-			'error',
-			{
-				allowParens: false,
-			},
-		],
 		'no-console': [
 			'error',
 			{


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

First, this rule was deprecated in ESLint v8.53.0. The alternative is the third-party plugin `@stylistic/eslint-plugin-js`.

Second, I sometimes feel annoyed by this rule. For example, see:

```js
const result = () => (type === 'foo' ? foo() : bar());
/*             ^^ Arrow function used ambiguously with a conditional expression [no-confusing-arrow] */
```

In this case, I think it's readable enough, thanks to `()` around the function body.
So, I think this rule is no longer necessary for this shared config.

Ref:
- https://eslint.org/docs/latest/rules/no-confusing-arrow
- https://eslint.org/blog/2023/10/deprecating-formatting-rules
- https://eslint.style/packages/js

> [!NOTE]
> This rule was added in #74.