### PR TITLE
Replace deprecated `padding-line-between-statements` with `@stylistic/js/padding-line-between-statements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Head
 
+- Changed: replace deprecated `padding-line-between-statements` with `@stylistic/js/padding-line-between-statements`.
 - Fixed: missing `funding` field in `package.json`.
 
 ## 21.0.0

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -9,6 +9,8 @@ const { ESLint } = require('eslint');
 const config = require('../index');
 const { isObject } = require('./helper');
 
+const newESLint = () => new ESLint({ baseConfig: config, useEslintrc: false, fix: true });
+
 test('basic properties of config', () => {
 	assert(isObject(config.parserOptions));
 	assert(isObject(config.env));
@@ -17,8 +19,48 @@ test('basic properties of config', () => {
 });
 
 test('load config in ESLint to validate all rule syntax is correct', async () => {
-	const eslint = new ESLint({ baseConfig: config, useEslintrc: false });
-	const results = await eslint.lintText('var foo\n');
+	const results = await newESLint().lintText('var foo\n');
 
 	assert(results);
+});
+
+test('padding-line-between-statements', async () => {
+	const code = `
+const asdf = 'dfsdf';
+function xxcv() {
+	const sdfsdf = 'sdfsdf';
+	return sdfsdf;
+}
+for (let i = 0; i < 10; i++) {
+	console.log(i);
+}
+const asdfsfd = 'sdfsdf';
+if (true) {
+	console.log('true');
+}
+`;
+
+	const results = await newESLint().lintText(code);
+
+	const expected = `
+const asdf = 'dfsdf';
+
+function xxcv() {
+	const sdfsdf = 'sdfsdf';
+
+	return sdfsdf;
+}
+
+for (let i = 0; i < 10; i++) {
+	console.log(i);
+}
+
+const asdfsfd = 'sdfsdf';
+
+if (true) {
+	console.log('true');
+}
+`;
+
+	assert.equal(results[0].output, expected);
 });

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
 		'plugin:regexp/recommended',
 		'prettier',
 	],
+	plugins: ['@stylistic/js'],
 	rules: {
 		'array-callback-return': 'error',
 		'dot-notation': 'error',
@@ -57,7 +58,16 @@ module.exports = {
 		'object-shorthand': 'error',
 		'one-var': ['error', 'never'],
 		'operator-assignment': 'error',
-		'padding-line-between-statements': [
+		'prefer-arrow-callback': 'error',
+		'prefer-object-spread': 'error',
+		'prefer-regex-literals': 'error',
+		'prefer-rest-params': 'error',
+		'prefer-spread': 'error',
+		'prefer-template': 'error',
+		'sort-imports': ['error', { allowSeparatedGroups: true }],
+
+		// Migrated from the deprecated built-in 'padding-line-between-statements'
+		'@stylistic/js/padding-line-between-statements': [
 			'error',
 			// Require blank lines after all directive prologues (e. g. 'use strict')
 			{
@@ -101,13 +111,6 @@ module.exports = {
 				next: '*',
 			},
 		],
-		'prefer-arrow-callback': 'error',
-		'prefer-object-spread': 'error',
-		'prefer-regex-literals': 'error',
-		'prefer-rest-params': 'error',
-		'prefer-spread': 'error',
-		'prefer-template': 'error',
-		'sort-imports': ['error', { allowSeparatedGroups: true }],
 
 		// Avoid a global variable unique to Node.js.
 		'n/prefer-global/process': ['error', 'never'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@stylistic/eslint-plugin-js": "^2.2.2",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-n": "^17.7.0",
         "eslint-plugin-regexp": "^2.6.0"
@@ -451,6 +452,69 @@
         "prettier": ">=3.0.0"
       }
     },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.2.2.tgz",
+      "integrity": "sha512-Vj2Q1YHVvJw+ThtOvmk5Yx7wZanVrIBRUTT89horLDb4xdP9GA1um9XOYQC6j67VeUC2gjZQnz5/RVJMzaOhtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "^8.56.10",
+        "acorn": "^8.11.3",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.12.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -460,8 +524,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -605,9 +668,10 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "prettier": "@stylelint/prettier-config",
   "dependencies": {
+    "@stylistic/eslint-plugin-js": "^2.2.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-n": "^17.7.0",
     "eslint-plugin-regexp": "^2.6.0"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #277

> Is there anything in the PR that needs further explanation?

Ref:
- https://eslint.style/rules/default/padding-line-between-statements
- https://eslint.style/packages/js#stylistic-eslint-plugin-js
