### PR TITLE
Change `eslint-plugin-n` config from `flag/recommended-script` to `flag/recommended` for CJS and ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const stylisticPlugin = require('@stylistic/eslint-plugin');
 
 module.exports = [
 	js.configs.recommended,
-	nPlugin.configs['flat/recommended-script'],
+	nPlugin.configs['flat/recommended'],
 	regexpPlugin.configs['flat/recommended'],
 	{
 		plugins: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `flat/recommended` (`recommended`) config of `eslint-plugin-n` considers both CommonJS and ES modules. I believe this is more flexible for our Stylelint repositories.

Ref <https://github.com/eslint-community/eslint-plugin-n/blob/v17.17.0/README.md#-configs>
