### PR TITLE
Add `eslint-plugin-jest` to `devDependencies` and bump it to 28.11.0

### DIFF
--- a/__tests__/jest.test.js
+++ b/__tests__/jest.test.js
@@ -21,4 +21,6 @@ test('load jest config in ESLint to validate all rule syntax is correct', async 
 	const results = await eslint.lintText('test("foo");');
 
 	assert(results);
+	assert.equal(results.length, 1);
+	assert.deepEqual(results[0].messages.map(m => m.ruleId), ['jest/no-disabled-tests', 'jest/expect-expect']);
 });

--- a/__tests__/jest.test.js
+++ b/__tests__/jest.test.js
@@ -22,5 +22,8 @@ test('load jest config in ESLint to validate all rule syntax is correct', async 
 
 	assert(results);
 	assert.equal(results.length, 1);
-	assert.deepEqual(results[0].messages.map(m => m.ruleId), ['jest/no-disabled-tests', 'jest/expect-expect']);
+	assert.deepEqual(
+		results[0].messages.map((m) => m.ruleId),
+		['jest/no-disabled-tests', 'jest/expect-expect'],
+	);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
         "eslint": "^9.23.0",
+        "eslint-plugin-jest": "^28.11.0",
         "np": "^10.2.0",
         "prettier": "^3.5.3"
       },
@@ -1903,12 +1904,11 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.8.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
-      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+      "version": "28.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
     "eslint": "^9.23.0",
+    "eslint-plugin-jest": "^28.11.0",
     "np": "^10.2.0",
     "prettier": "^3.5.3"
   },


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Unless a dependency is in `dependencies` or `devDependencies`, Dependabot doesn't bump it.
This allows Dependabot to create a pull request to bump `eslint-plugin-jest`.

Note: this won't impact on users because `peerDependencies` doesn't change.

https://github.com/jest-community/eslint-plugin-jest/releases/tag/v28.11.0 was released in January 2025 (about 3 months ago).
