### PR TITLE
Shorten dependency group name by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     labels:
       - 'pr: dependencies'
     groups:
-      development-dependencies:
+      dev-deps:
         dependency-type: 'development'
         exclude-patterns: ['eslint', 'eslint-*']
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

"development-dependencies" seems a bit too long in a PR title. Shorter titles with "dev-deps" are more readable and still clear. 

E.g.,

```diff
-Bump prettier from 3.5.3 to 3.6.0 in the development-dependencies group
+Bump prettier from 3.5.3 to 3.6.0 in the dev-deps group
```

