### PR TITLE
Require owner review for `.npmrc`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 
 # Require approvals by the owners team when updating dependencies or package metadata.
 package.json @stylelint/owners
+
+# Require approvals by the owners team when updating npm configuration.
+.npmrc @stylelint/owners


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #426

> Is there anything in the PR that needs further explanation?

`.npmrc` now holds security-sensitive npm settings.
